### PR TITLE
Separate Test Job in CI/CD Pipeline

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -33,9 +33,6 @@ jobs:
     - name: Build Project
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
 
-    - name: Run Tests
-      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
-
     - name: Publish Project
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
 
@@ -45,13 +42,27 @@ jobs:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
-  deploy:
+  test:
     runs-on: windows-latest
     needs: build
-    environment: develop
 
     steps:
     - name: Download Artifact from Build Job
+      uses: actions/download-artifact@v3
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+    - name: Run Tests
+      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
+
+  deploy:
+    runs-on: windows-latest
+    needs: test
+    environment: develop
+
+    steps:
+    - name: Download Artifact from Test Job
       uses: actions/download-artifact@v3
       with:
         name: webapp

--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -47,11 +47,19 @@ jobs:
     needs: build
 
     steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
     - name: Download Artifact from Build Job
       uses: actions/download-artifact@v3
       with:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
 
     - name: Run Tests
       run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build

--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -47,11 +47,19 @@ jobs:
     needs: build
 
     steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
     - name: Download Artifact from Build Job
       uses: actions/download-artifact@v3
       with:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
 
     - name: Run Tests
       run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build

--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -33,9 +33,6 @@ jobs:
     - name: Build Project
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
 
-    - name: Run Tests
-      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
-
     - name: Publish Project
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
 
@@ -45,13 +42,27 @@ jobs:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
-  deploy:
+  test:
     runs-on: windows-latest
     needs: build
-    environment: production
 
     steps:
     - name: Download Artifact from Build Job
+      uses: actions/download-artifact@v3
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+    - name: Run Tests
+      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
+
+  deploy:
+    runs-on: windows-latest
+    needs: test
+    environment: production
+
+    steps:
+    - name: Download Artifact from Test Job
       uses: actions/download-artifact@v3
       with:
         name: webapp

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -47,11 +47,19 @@ jobs:
     needs: build
 
     steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
     - name: Download Artifact from Build Job
       uses: actions/download-artifact@v3
       with:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
 
     - name: Run Tests
       run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -33,9 +33,6 @@ jobs:
     - name: Build Project
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
 
-    - name: Run Tests
-      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
-
     - name: Publish Project
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}"
 
@@ -45,13 +42,27 @@ jobs:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
-  deploy:
+  test:
     runs-on: windows-latest
     needs: build
-    environment: staging
 
     steps:
     - name: Download Artifact from Build Job
+      uses: actions/download-artifact@v3
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+    - name: Run Tests
+      run: dotnet test "${{ env.WORKING_DIRECTORY }}" --no-build
+
+  deploy:
+    runs-on: windows-latest
+    needs: test
+    environment: staging
+
+    steps:
+    - name: Download Artifact from Test Job
       uses: actions/download-artifact@v3
       with:
         name: webapp


### PR DESCRIPTION
This merge request implements a change in our CI/CD pipeline by separating the test job into its own stage. Previously, the test step was part of the build job, but now it is an independent job that runs after the build job. This change aims to improve pipeline organization and make it easier to identify and debug issues in the testing phase