### PR TITLE
Fix/Restore deploy steps accidentally removed 

### DIFF
--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -89,4 +89,12 @@ jobs:
     - name: Download Artifact from Test Job
       uses: actions/download-artifact@v3
       with:
-        name:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+
+    - name: Deploy to Azure WebApp
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: ${{ env.AZURE_WEBAPP_NAME }}
+        publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_STAGING }}
+        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}


### PR DESCRIPTION
Restored the deploy steps in the pipeline configuration that were accidentally removed. These steps are essential for downloading the artifact from the test job and ensuring the deployment process functions correctly.