### PR TITLE
Add EventRegistration entity and implement GetTicketTypeCounts endpoint

### DIFF
--- a/EventMS.Application/DTOs/Tickets/TicketTypeCountDto.cs
+++ b/EventMS.Application/DTOs/Tickets/TicketTypeCountDto.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventMS.Application.DTOs.Tickets
+{
+    public class TicketTypeCountDto
+    {
+        public string TypeName { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/EventMS.Application/Ports/Ticket/ICreateTypeTicketUseCase.cs
+++ b/EventMS.Application/Ports/Ticket/ICreateTypeTicketUseCase.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EventMS.Application.Ports
+namespace EventMS.Application.Ports.Ticket
 {
     public interface ICreateTypeTicketUseCase
     {

--- a/EventMS.Application/Ports/Ticket/IGetTicketTypeCountsUseCase.cs
+++ b/EventMS.Application/Ports/Ticket/IGetTicketTypeCountsUseCase.cs
@@ -1,0 +1,14 @@
+﻿using EventMS.Application.DTOs.Tickets;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventMS.Application.Ports.Ticket
+{
+    public interface IGetTicketTypeCountsUseCase
+    {
+        IEnumerable<TicketTypeCountDto> Execute(int eventId);
+    }
+}

--- a/EventMS.Application/UseCases/Ticket/CreateTypeTicketUseCase.cs
+++ b/EventMS.Application/UseCases/Ticket/CreateTypeTicketUseCase.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using EventMS.Application.DTOs.Tickets;
-using EventMS.Application.Ports;
+using EventMS.Application.Ports.Ticket;
 using EventMS.Domain.Entities;
 using EventMS.Domain.Interfaces;
 using System;
@@ -9,9 +9,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EventMS.Application.UseCases
+namespace EventMS.Application.UseCases.Ticket
 {
-    internal class CreateTypeTicketUseCase : ICreateTypeTicketUseCase
+    public class CreateTypeTicketUseCase : ICreateTypeTicketUseCase
     {
         private readonly ITypeTicketRepository _typeTicketRepository;
         private readonly IMapper _mapper;

--- a/EventMS.Application/UseCases/Ticket/GetTicketTypeCountsUseCase .cs
+++ b/EventMS.Application/UseCases/Ticket/GetTicketTypeCountsUseCase .cs
@@ -1,0 +1,30 @@
+﻿using AutoMapper;
+using EventMS.Application.DTOs.Tickets;
+using EventMS.Application.Ports.Ticket;
+using EventMS.Domain.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventMS.Application.UseCases.Ticket
+{
+    public class GetTicketTypeCountsUseCase : IGetTicketTypeCountsUseCase
+    {
+        private readonly ITypeTicketRepository _typeTicketRepository;
+        private readonly IMapper _mapper;
+
+        public GetTicketTypeCountsUseCase(ITypeTicketRepository typeTicketRepository, IMapper mapper)
+        {
+            _typeTicketRepository = typeTicketRepository;
+            _mapper = mapper;
+        }
+
+        public IEnumerable<TicketTypeCountDto> Execute(int eventId)
+        {
+            var ticketTypeCounts = _typeTicketRepository.GetTicketTypeCounts(eventId);
+            return _mapper.Map<IEnumerable<TicketTypeCountDto>>(ticketTypeCounts);
+        }
+    }
+}

--- a/EventMS.Domain/Entities/Event.cs
+++ b/EventMS.Domain/Entities/Event.cs
@@ -28,12 +28,14 @@ namespace EventMS.Domain.Entities
             _time = time;
             _location = location;
             _tickets = new List<Ticket>();
+            EventRegistrations = new List<EventRegistration>();
         }
 
         // Constructor sin parámetros requerido por EF
         private Event()
         {
             _tickets = new List<Ticket>();
+            EventRegistrations = new List<EventRegistration>();
         }
 
         public int Id { get; set; }
@@ -43,6 +45,7 @@ namespace EventMS.Domain.Entities
         public TimeSpan Time { get; private set; }
         public string Location => _location;
         public IReadOnlyCollection<Ticket> Tickets => _tickets.AsReadOnly();
+        public ICollection<EventRegistration> EventRegistrations { get; private set; }
 
         public void UpdateDetails(string title, string description, DateTime date, TimeSpan time, string location)
         {

--- a/EventMS.Domain/Entities/EventRegistration.cs
+++ b/EventMS.Domain/Entities/EventRegistration.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventMS.Domain.Entities
+{
+    public class EventRegistration
+    {
+        public string UserId { get; set; }
+        public User User { get; set; }
+
+        public int EventId { get; set; }
+        public Event Event { get; set; }
+
+        public DateTime RegistrationDate { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/EventMS.Domain/Entities/TypeTicketCount.cs
+++ b/EventMS.Domain/Entities/TypeTicketCount.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventMS.Domain.Entities
+{
+    public class TypeTicketCount
+    {
+        public TypeTicket TypeTicket { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/EventMS.Domain/Entities/User.cs
+++ b/EventMS.Domain/Entities/User.cs
@@ -19,6 +19,7 @@ namespace EventMS.Domain.Entities
         private User()
         {
             _tickets = new List<Ticket>();
+            EventRegistrations = new List<EventRegistration>();
         }
 
         public User(string userId, string name, string surname, string email, string nickname, string role)
@@ -30,6 +31,7 @@ namespace EventMS.Domain.Entities
             _nickname = nickname;
             _role = role;
             _tickets = new List<Ticket>();
+            EventRegistrations = new List<EventRegistration>();
         }
 
         public string Id { get; private set; } // This is the 'sub' from the token
@@ -39,6 +41,7 @@ namespace EventMS.Domain.Entities
         public string Nickname => _nickname;
         public string Role => _role;
         public IReadOnlyCollection<Ticket> Tickets => _tickets.AsReadOnly();
+        public ICollection<EventRegistration> EventRegistrations { get; private set; }
 
         public void UpdateContactInformation(string name, string surname, string email, string nickname, string role)
         {

--- a/EventMS.Domain/Interfaces/ITypeTicketRepository.cs
+++ b/EventMS.Domain/Interfaces/ITypeTicketRepository.cs
@@ -13,5 +13,6 @@ namespace EventMS.Domain.Interfaces
         TypeTicket GetTypeTicketById(int id);
         void AddTypeTicket(TypeTicket typeTicket);
         void UpdateTypeTicket(TypeTicket typeTicket);
+        IEnumerable<TypeTicketCount> GetTicketTypeCounts(int eventId);
     }
 }

--- a/EventMS.Infrastructure/Data/ApplicationDbContext.cs
+++ b/EventMS.Infrastructure/Data/ApplicationDbContext.cs
@@ -78,7 +78,7 @@ namespace EventMS.Infrastructure.Data
             builder.Property(tt => tt.Description).IsRequired();
             builder.Property(tt => tt.Price)
                    .IsRequired()
-                   .HasColumnType("decimal(18,2)"); // Especifica la precisión y la escala
+                   .HasColumnType("decimal(18,2)"); 
             builder.Property(tt => tt.QuantityAvailable).IsRequired();
 
             builder.HasMany(tt => tt.Tickets)

--- a/EventMS.Infrastructure/Data/ApplicationDbContext.cs
+++ b/EventMS.Infrastructure/Data/ApplicationDbContext.cs
@@ -17,6 +17,7 @@ namespace EventMS.Infrastructure.Data
         public DbSet<Ticket> Tickets { get; set; }
         public DbSet<User> Users { get; set; }
         public DbSet<TypeTicket> TypeTickets { get; set; }
+        public DbSet<EventRegistration> EventRegistrations { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -26,6 +27,7 @@ namespace EventMS.Infrastructure.Data
             modelBuilder.Entity<Ticket>(ConfigureTicket);
             modelBuilder.Entity<User>(ConfigureUser);
             modelBuilder.Entity<TypeTicket>(ConfigureTypeTicket);
+            modelBuilder.Entity<EventRegistration>(ConfigureEventRegistration);
         }
 
         private void ConfigureEvent(EntityTypeBuilder<Event> builder)
@@ -84,6 +86,18 @@ namespace EventMS.Infrastructure.Data
             builder.HasMany(tt => tt.Tickets)
                    .WithOne(t => t.TypeTicket)
                    .HasForeignKey(t => t.TypeTicketId);
+        }
+        private void ConfigureEventRegistration(EntityTypeBuilder<EventRegistration> builder)
+        {
+            builder.HasKey(er => new { er.UserId, er.EventId });
+
+            builder.HasOne(er => er.User)
+                   .WithMany(u => u.EventRegistrations)
+                   .HasForeignKey(er => er.UserId);
+
+            builder.HasOne(er => er.Event)
+                   .WithMany(e => e.EventRegistrations)
+                   .HasForeignKey(er => er.EventId);
         }
     }
 }

--- a/EventMS.Infrastructure/Migrations/20240630011251_AddEventRegistration.Designer.cs
+++ b/EventMS.Infrastructure/Migrations/20240630011251_AddEventRegistration.Designer.cs
@@ -4,6 +4,7 @@ using EventMS.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EventMS.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240630011251_AddEventRegistration")]
+    partial class AddEventRegistration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EventMS.Infrastructure/Migrations/20240630011251_AddEventRegistration.cs
+++ b/EventMS.Infrastructure/Migrations/20240630011251_AddEventRegistration.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EventMS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEventRegistration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EventRegistrations",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    EventId = table.Column<int>(type: "int", nullable: false),
+                    RegistrationDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EventRegistrations", x => new { x.UserId, x.EventId });
+                    table.ForeignKey(
+                        name: "FK_EventRegistrations_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EventRegistrations_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventRegistrations_EventId",
+                table: "EventRegistrations",
+                column: "EventId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EventRegistrations");
+        }
+    }
+}

--- a/EventMS.Infrastructure/Repositories/TypeTicketRepository.cs
+++ b/EventMS.Infrastructure/Repositories/TypeTicketRepository.cs
@@ -38,5 +38,18 @@ namespace EventMS.Infrastructure.Repositories
             _context.TypeTickets.Update(typeTicket);
             _context.SaveChanges();
         }
+
+        public IEnumerable<TypeTicketCount> GetTicketTypeCounts(int eventId)
+        {
+            return _context.Tickets
+                .Where(t => t.EventId == eventId)
+                .GroupBy(t => t.TypeTicket)
+                .Select(g => new TypeTicketCount
+                {
+                    TypeTicket = g.Key,
+                    Count = g.Count()
+                })
+                .ToList();
+        }
     }
 }

--- a/EventManagementSystemAPI.Tests/TypeTicketController.cs
+++ b/EventManagementSystemAPI.Tests/TypeTicketController.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventManagementSystemAPI.Tests
+{
+    public class TypeTicketController
+    {
+    }
+}

--- a/EventManagementSystemAPI/Controllers/TypeTicketController.cs
+++ b/EventManagementSystemAPI/Controllers/TypeTicketController.cs
@@ -1,11 +1,11 @@
 ﻿using EventManagementSystemAPI.Filters.validations;
 using EventMS.Application.DTOs.Tickets;
-using EventMS.Application.Ports;
 using EventMS.Domain.Entities;
 using EventMS.Infrastructure.Auth.TokenManagement;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using EventManagementSystemAPI.Models;
+using EventMS.Application.Ports.Ticket;
 
 
 namespace EventManagementSystemAPI.Controllers
@@ -16,10 +16,14 @@ namespace EventManagementSystemAPI.Controllers
     public class TypeTicketController : ControllerBase
     {
         private readonly ICreateTypeTicketUseCase _createTypeTicketUseCase;
+        private readonly IGetTicketTypeCountsUseCase _getTicketTypeCountsUseCase;
 
-        public TypeTicketController(ICreateTypeTicketUseCase createTypeTicketUseCase)
+        public TypeTicketController
+            (ICreateTypeTicketUseCase createTypeTicketUseCase,
+            IGetTicketTypeCountsUseCase getTicketTypeCountsUseCase)
         {
             _createTypeTicketUseCase = createTypeTicketUseCase;
+            _getTicketTypeCountsUseCase = getTicketTypeCountsUseCase;
         }
 
         [Authorize(Policy = ApiPolicies.OrganizerClientRole)]
@@ -66,6 +70,27 @@ namespace EventManagementSystemAPI.Controllers
             }
 
         }
-    }
 
+        [Authorize(Policy = "OrganizerClientRole")]
+        [HttpGet("{eventId}/ticket-types/count")]
+        public IActionResult GetTicketTypeCounts(int eventId)
+        {
+            var ticketTypeCounts = _getTicketTypeCountsUseCase.Execute(eventId);
+
+            if (!ticketTypeCounts.Any())
+            {
+                return NotFound(new Response<string>(
+                    404,
+                    "No ticket types found for the specified event.",
+                    null
+                ));
+            }
+
+            return Ok(new Response<IEnumerable<TicketTypeCountDto>>(
+                200,
+                "Ticket type counts retrieved successfully.",
+                ticketTypeCounts
+            ));
+        }
+    }
 }

--- a/EventManagementSystemAPI/MappingProfile/MappingProfile.cs
+++ b/EventManagementSystemAPI/MappingProfile/MappingProfile.cs
@@ -26,6 +26,8 @@ namespace EventManagementSystemAPI.MappingProfile
             CreateMap<User, UserDto>();
             CreateMap<TypeTicket, TypeTicketDto>().ReverseMap();
 
+            CreateMap<TypeTicketCount, TicketTypeCountDto>()
+            .ForMember(dest => dest.TypeName, opt => opt.MapFrom(src => src.TypeTicket.Name));
         }
     }
 }

--- a/EventManagementSystemAPI/Util/DependecyInjectionManager.cs
+++ b/EventManagementSystemAPI/Util/DependecyInjectionManager.cs
@@ -1,7 +1,9 @@
 ﻿using EventManagementSystemAPI.Filters;
 using EventMS.Application.Port;
 using EventMS.Application.Ports;
+using EventMS.Application.Ports.Ticket;
 using EventMS.Application.UseCases;
+using EventMS.Application.UseCases.Ticket;
 using EventMS.Application.UseCases.UserUseCases;
 using EventMS.Domain.Interfaces;
 using EventMS.Infrastructure.Repositories;
@@ -15,6 +17,7 @@ namespace EventManagementSystemAPI.Util
         {
             services.AddScoped<IEventRepository, EventRepository>();
             services.AddScoped<IUserRepository, UserRepository>();
+            services.AddScoped<ITypeTicketRepository, TypeTicketRepository>();
         }
 
         public static void AddUseCases(this IServiceCollection services)
@@ -28,6 +31,9 @@ namespace EventManagementSystemAPI.Util
 
             services.AddScoped<IGetAllUsersUseCase, GetAllUsersUseCase>();
             services.AddScoped<IGetUserByIdUseCase, GetUserByIdUseCase>();
+
+            services.AddScoped<ICreateTypeTicketUseCase, CreateTypeTicketUseCase>();
+            services.AddScoped<IGetTicketTypeCountsUseCase, GetTicketTypeCountsUseCase>();
         }
 
     }


### PR DESCRIPTION
This pull request includes the following changes:

1. Implemented GetTicketTypeCounts endpoint:
   - Added GetTicketTypeCounts endpoint in TypeTicketController to retrieve ticket type counts for a specific event.
   - Created DTO TicketTypeCountDto for data transfer.
   - Implemented GetTicketTypeCountsUseCase to handle the business logic.
   - Updated TypeTicketRepository to include method for fetching ticket type counts.
   - Configured mappings in MappingProfile.

2. Added EventRegistration entity:
   - Created EventRegistration entity to represent the many-to-many relationship between User and Event.
   - Configured the relationship in ApplicationDbContext.
   - Updated User and Event entities to include collections of EventRegistrations.
   - Added migration to create the EventRegistration table.

